### PR TITLE
Allow all cache behavior TTL values to be user-configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Terraform Munki Repo
 
-`terraform-munki-repo` is a [Terraform](https://terraform.io) module that will set up a production-ready Munki repo for you. More specifically, it will create:
+`terraform-munki-repo` is a [Terraform](https://terraform.io) module that will set up a production-ready Munki repo for you. It is designed for use with Terraform 0.11.x More specifically, it will create:
 
 * An S3 bucket to store your Munki repo
 * An S3 bucket to store your logs

--- a/s3.tf
+++ b/s3.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "www" {
-  bucket = "${var.munki_s3_bucket}"
+  bucket = "${var.prefix}-${var.munki_s3_bucket}"
 
   logging {
     target_bucket = "${aws_s3_bucket.log_bucket.id}"
@@ -45,7 +45,7 @@ resource "aws_s3_bucket_policy" "www" {
 }
 
 resource "aws_s3_bucket" "log_bucket" {
-  bucket = "${var.munki_s3_bucket}-logs"
+  bucket = "${var.prefix}-${var.munki_s3_bucket}-logs"
   acl    = "log-delivery-write"
 
   lifecycle_rule {


### PR DESCRIPTION
This PR will apply a change that would allow the user to configure the cache behavior TTL values.

The default values for each config key are set to the same thing as what they are currently defined as and, therefore, should be a no-op.

This change will allow the user to customize the CloudFront distribution a bit more (if they so desire).