### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ provider "aws" {
 
 module "munki-repo" {
   source  = "grahamgilbert/munki-repo/aws"
-  version = "0.1.11"
+  version = "0.1.12"
   munki_s3_bucket = "${var.munki_s3_bucket}"
   username        = "${var.username}"
   password        = "${var.password}"


### PR DESCRIPTION
This PR updates the module version to the latest version in the example main.tf. 

Version 0.1.11 does not use the "prefix" variable when naming the s3 bucket, so if you follow the readme and create a globally unique prefix but leave the "munki-s3-bucket" name as is, you will still get an error that the bucket already exists when running terraform apply. This is a bit unexpected as the documentation implies that the bucket name will use the prefix (as it does in version 0.1.12).

