### PR TITLE
Add object caching rules for icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,21 @@ variable "manifests_ordered_cache_behavior_max_ttl" {
   default = 60
 }
 
+# minimum amount of time (in seconds) that you want icon objects to stay in CloudFront caches before CloudFront queries your origin to see whether the object has been updated
+variable "icons_ordered_cache_behavior_min_ttl" {
+  default = 0
+}
+
+# default amount of time (in seconds) that a icon object is in a CloudFront cache before CloudFront forwards another request in the absence of an Cache-Control max-age or Expires header
+variable "icons_ordered_cache_behavior_default_ttl" {
+  default = 30
+}
+
+# maximum amount of time (in seconds) that a icon object is in a CloudFront cache before CloudFront forwards another request to your origin to determine whether the object has been updated
+variable "icons_ordered_cache_behavior_max_ttl" {
+  default = 60
+}
+
 
 # NOTE: currently the _only_ supported provider region is us-east-1.
 provider "aws" {

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -94,6 +94,32 @@ resource "aws_cloudfront_distribution" "www_distribution" {
     }
   }
 
+  ordered_cache_behavior {
+    path_pattern = "/icons/*"
+
+    lambda_function_association {
+      event_type = "viewer-request"
+      lambda_arn = "${aws_lambda_function.basic_auth_lambda.arn}:${aws_lambda_function.basic_auth_lambda.version}"
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+    compress               = true
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    min_ttl                = "${var.icons_ordered_cache_behavior_min_ttl}"
+    default_ttl            = "${var.icons_ordered_cache_behavior_default_ttl}"
+    max_ttl                = "${var.icons_ordered_cache_behavior_max_ttl}"
+    target_origin_id       = "munki"
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+  }
+
   restrictions {
     geo_restriction {
       restriction_type = "none"


### PR DESCRIPTION
This PR will apply a change that will create an object caching rule for the icons directory and allow TTL values to be user configured the same as catalog and manifest objects.