### PR TITLE
Update AWS provider lock.

### DIFF
--- a/provider.tf
+++ b/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.59.0"
+      version = "~> 3.59"
     }
   }
 }


### PR DESCRIPTION
The following makes a small change to the AWS provider version  [~>](https://www.terraform.io/language/expressions/version-constraints#-3): Allows only the rightmost version component to increment. For example, to allow new patch releases within a specific minor release, use the full version number: ~> 1.0.4 will allow installation of 1.0.5 and 1.0.10 but not 1.1.0. This is usually called the pessimistic constraint operator.

 `"~> 3.59.0"` in this case is actually a pin to `3.59.0` as it's unlikely there will ever be a minor dot  release.

This allows all providers `> 3.59` up until `4.0` 


References 

https://github.com/hashicorp/terraform-provider-aws/issues/20433 

https://www.terraform.io/language/expressions/version-constraints#version-constraint-syntax