### PR TITLE
Migrate to `templatefile` function

### DIFF
--- a/lambda.tf
+++ b/lambda.tf
@@ -21,20 +21,18 @@ resource "aws_iam_role" "iam_for_lambda" {
 EOF
 }
 
-data "template_file" "basic_auth_js" {
-  template = file("${path.module}/basic_auth.js.tpl")
-
-  vars = {
+locals {
+  basic_auth_js = templatefile("${path.module}/basic_auth.js.tpl", {
     username = var.username
     password = var.password
-  }
+  })
 }
 
 data "archive_file" "basic_auth_lambda_zip" {
   type = "zip"
 
   output_path             = "basic_auth_lambda.zip"
-  source_content          = data.template_file.basic_auth_js.rendered
+  source_content          = local.basic_auth_js
   source_content_filename = "basic_auth.js"
 }
 

--- a/provider.tf
+++ b/provider.tf
@@ -8,6 +8,6 @@ terraform {
 }
 
 provider "aws" {
-  alias   = "use1"
-  region  = "us-east-1"
+  alias  = "use1"
+  region = "us-east-1"
 }


### PR DESCRIPTION
When performing `terraform init` on an M1 Mac I received an error regarding the `template` provider
```
│ Error: Incompatible provider version
│ 
│ Provider registry.terraform.io/hashicorp/template v2.2.0 does not have a package available for your current platform, darwin_arm64.
│ 
│ Provider releases are separate from Terraform CLI releases, so not all providers are available for all platforms. Other versions of this provider
│ may have different platforms supported.
```

Per https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file, it looks like the best action is to use the built in template rendering engine.

>In Terraform 0.12 and later, [the templatefile function](https://www.terraform.io/docs/configuration/functions/templatefile.html?_ga=2.74161616.375502302.1651597817-1851288348.1651597817) offers a built-in mechanism for rendering a template from a file. Use that function instead, unless you are using Terraform 0.11 or earlier.