### PR TITLE
Update Module for Modern AWS Terraform Provider Compatibility

### DIFF
--- a/provider.tf
+++ b/provider.tf
@@ -8,6 +8,6 @@ terraform {
 }
 
 provider "aws" {
-  alias   = "use1"
-  region  = "us-east-1"
+  alias  = "use1"
+  region = "us-east-1"
 }

--- a/provider.tf
+++ b/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.59.0"
+      version = "~> 4.64.0"
     }
   }
 }

--- a/s3.tf
+++ b/s3.tf
@@ -56,7 +56,7 @@ resource "aws_s3_bucket" "log_bucket" {
 }
 
 resource "aws_s3_bucket_acl" "log_bucket_acl" {
-  bucket = aws_s3_bucket.www.id
+  bucket = aws_s3_bucket.log_bucket.id
   acl    = "log-delivery-write"
 }
 

--- a/s3.tf
+++ b/s3.tf
@@ -12,7 +12,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "bucket_sse_config
 
   rule {
     apply_server_side_encryption_by_default {
-      sse_algorithm     = "AES256"
+      sse_algorithm = "AES256"
     }
   }
 }
@@ -58,16 +58,16 @@ resource "aws_s3_bucket_acl" "log_bucket_acl" {
   acl    = "log-delivery-write"
 }
 
-resource aws_s3_bucket_lifecycle_configuration "log_bucket_lifecycle" {
+resource "aws_s3_bucket_lifecycle_configuration" "log_bucket_lifecycle" {
   bucket = aws_s3_bucket.log_bucket.id
 
   rule {
-    id      = "log_bucket_lifecycle"
+    id     = "log_bucket_lifecycle"
     status = "Enabled"
-  
+
     transition {
-        days          = "30"
-        storage_class = "STANDARD_IA"
-      }
+      days          = "30"
+      storage_class = "STANDARD_IA"
+    }
   }
 }

--- a/s3.tf
+++ b/s3.tf
@@ -1,10 +1,12 @@
 resource "aws_s3_bucket" "www" {
   bucket = "${var.prefix}-${var.munki_s3_bucket}"
+}
 
-  logging {
-    target_bucket = aws_s3_bucket.log_bucket.id
-    target_prefix = "logs/"
-  }
+resource "aws_s3_bucket_logging" "www_logging" {
+  bucket = aws_s3_bucket.www.id
+
+  target_bucket = aws_s3_bucket.log_bucket.id
+  target_prefix = "logs/"
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "bucket_sse_config" {
@@ -12,7 +14,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "bucket_sse_config
 
   rule {
     apply_server_side_encryption_by_default {
-      sse_algorithm = "AES256"
+      sse_algorithm     = "AES256"
     }
   }
 }
@@ -58,16 +60,16 @@ resource "aws_s3_bucket_acl" "log_bucket_acl" {
   acl    = "log-delivery-write"
 }
 
-resource "aws_s3_bucket_lifecycle_configuration" "log_bucket_lifecycle" {
+resource aws_s3_bucket_lifecycle_configuration "log_bucket_lifecycle" {
   bucket = aws_s3_bucket.log_bucket.id
 
   rule {
-    id     = "log_bucket_lifecycle"
+    id      = "log_bucket_lifecycle"
     status = "Enabled"
-
+  
     transition {
-      days          = "30"
-      storage_class = "STANDARD_IA"
-    }
+        days          = "30"
+        storage_class = "STANDARD_IA"
+      }
   }
 }


### PR DESCRIPTION
This pull request will perform the following changes:
- Removes the `acl` argument from the `aws_s3_bucket` resource (as that argument has been deprecated)
- Removes the `server_side_encryption_configuration` argument from the `aws_s3_bucket`  (as that argument has been deprecated)
- Removes the `logging` argument from `aws_s3_bucket` resource (as that argument has been deprecated) 
- Adds a new `aws_s3_bucket_acl` resource -- for both Munki assets && logging S3 buckets -- and sets the `acl` argument to `private` and `log-delivery-write`, respectively
- Adds a new `aws_s3_bucket_lifecycle_configuration` resource for the logging bucket and sets the `storage_class` and `days` arguments (within the `transition` block) to the same values as were used previously
- Adds a new `aws_s3_bucket_logging` resource for the Munki assets bucket and targets the logs to the logging bucket with the same prefix as before
- Updates the defined `aws` provider version to the current latest release

I tested this module within a fairly empty AWS account and there were no errors output. I believe that the resulting infrastructure should be pretty much the same as before my changes were introduced but its probably worth giving these changes a keen eye. Here's the `plan` output:

<details>
  <summary>Plan</summary>

``` hcl
Terraform will perform the following actions:

  # module.munki-repo.data.aws_iam_policy_document.s3_policy will be read during apply
  # (config refers to values not yet known)
 <= data "aws_iam_policy_document" "s3_policy" {
      + id   = (known after apply)
      + json = (known after apply)

      + statement {
          + actions   = [
              + "s3:GetObject",
            ]
          + resources = [
              + (known after apply),
            ]

          + principals {
              + identifiers = [
                  + (known after apply),
                ]
              + type        = "AWS"
            }
        }
      + statement {
          + actions   = [
              + "s3:ListBucket",
            ]
          + resources = [
              + (known after apply),
            ]

          + principals {
              + identifiers = [
                  + (known after apply),
                ]
              + type        = "AWS"
            }
        }
    }

  # module.munki-repo.aws_cloudfront_distribution.www_distribution will be created
  + resource "aws_cloudfront_distribution" "www_distribution" {
      + arn                            = (known after apply)
      + caller_reference               = (known after apply)
      + default_root_object            = "index.html"
      + domain_name                    = (known after apply)
      + enabled                        = true
      + etag                           = (known after apply)
      + hosted_zone_id                 = (known after apply)
      + http_version                   = "http2"
      + id                             = (known after apply)
      + in_progress_validation_batches = (known after apply)
      + is_ipv6_enabled                = false
      + last_modified_time             = (known after apply)
      + price_class                    = "PriceClass_100"
      + retain_on_delete               = false
      + status                         = (known after apply)
      + trusted_key_groups             = (known after apply)
      + trusted_signers                = (known after apply)
      + wait_for_deployment            = true

      + default_cache_behavior {
          + allowed_methods        = [
              + "GET",
              + "HEAD",
            ]
          + cached_methods         = [
              + "GET",
              + "HEAD",
            ]
          + compress               = true
          + default_ttl            = 86400
          + max_ttl                = 31536000
          + min_ttl                = 0
          + target_origin_id       = "munki"
          + trusted_key_groups     = (known after apply)
          + trusted_signers        = (known after apply)
          + viewer_protocol_policy = "redirect-to-https"

          + forwarded_values {
              + headers                 = (known after apply)
              + query_string            = false
              + query_string_cache_keys = (known after apply)

              + cookies {
                  + forward           = "none"
                  + whitelisted_names = (known after apply)
                }
            }

          + lambda_function_association {
              + event_type   = "viewer-request"
              + include_body = false
              + lambda_arn   = (known after apply)
            }
        }

      + ordered_cache_behavior {
          + allowed_methods        = [
              + "GET",
              + "HEAD",
            ]
          + cached_methods         = [
              + "GET",
              + "HEAD",
            ]
          + compress               = true
          + default_ttl            = 30
          + max_ttl                = 60
          + min_ttl                = 0
          + path_pattern           = "/catalogs/*"
          + target_origin_id       = "munki"
          + viewer_protocol_policy = "redirect-to-https"

          + forwarded_values {
              + headers                 = (known after apply)
              + query_string            = false
              + query_string_cache_keys = (known after apply)

              + cookies {
                  + forward = "none"
                }
            }

          + lambda_function_association {
              + event_type   = "viewer-request"
              + include_body = false
              + lambda_arn   = (known after apply)
            }
        }
      + ordered_cache_behavior {
          + allowed_methods        = [
              + "GET",
              + "HEAD",
            ]
          + cached_methods         = [
              + "GET",
              + "HEAD",
            ]
          + compress               = true
          + default_ttl            = 30
          + max_ttl                = 60
          + min_ttl                = 0
          + path_pattern           = "/manifests/*"
          + target_origin_id       = "munki"
          + viewer_protocol_policy = "redirect-to-https"

          + forwarded_values {
              + headers                 = (known after apply)
              + query_string            = false
              + query_string_cache_keys = (known after apply)

              + cookies {
                  + forward = "none"
                }
            }

          + lambda_function_association {
              + event_type   = "viewer-request"
              + include_body = false
              + lambda_arn   = (known after apply)
            }
        }
      + ordered_cache_behavior {
          + allowed_methods        = [
              + "GET",
              + "HEAD",
            ]
          + cached_methods         = [
              + "GET",
              + "HEAD",
            ]
          + compress               = true
          + default_ttl            = 30
          + max_ttl                = 60
          + min_ttl                = 0
          + path_pattern           = "/icons/*"
          + target_origin_id       = "munki"
          + viewer_protocol_policy = "redirect-to-https"

          + forwarded_values {
              + headers                 = (known after apply)
              + query_string            = false
              + query_string_cache_keys = (known after apply)

              + cookies {
                  + forward = "none"
                }
            }

          + lambda_function_association {
              + event_type   = "viewer-request"
              + include_body = false
              + lambda_arn   = (known after apply)
            }
        }

      + origin {
          + connection_attempts = 3
          + connection_timeout  = 10
          + domain_name         = (known after apply)
          + origin_id           = "munki"

          + s3_origin_config {
              + origin_access_identity = (known after apply)
            }
        }

      + restrictions {
          + geo_restriction {
              + locations        = (known after apply)
              + restriction_type = "none"
            }
        }

      + viewer_certificate {
          + cloudfront_default_certificate = true
          + minimum_protocol_version       = "TLSv1"
        }
    }

  # module.munki-repo.aws_cloudfront_origin_access_identity.origin_access_identity will be created
  + resource "aws_cloudfront_origin_access_identity" "origin_access_identity" {
      + caller_reference                = (known after apply)
      + cloudfront_access_identity_path = (known after apply)
      + comment                         = "Some comment"
      + etag                            = (known after apply)
      + iam_arn                         = (known after apply)
      + id                              = (known after apply)
      + s3_canonical_user_id            = (known after apply)
    }

  # module.munki-repo.aws_iam_role.iam_for_lambda will be created
  + resource "aws_iam_role" "iam_for_lambda" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = [
                              + "lambda.amazonaws.com",
                              + "edgelambda.amazonaws.com",
                            ]
                        }
                      + Sid       = ""
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "this-is-my-prefix-_iam_for_lambda"
      + name_prefix           = (known after apply)
      + path                  = "/"
      + role_last_used        = (known after apply)
      + unique_id             = (known after apply)

      + inline_policy {
          + name   = (known after apply)
          + policy = (known after apply)
        }
    }

  # module.munki-repo.aws_lambda_function.basic_auth_lambda will be created
  + resource "aws_lambda_function" "basic_auth_lambda" {
      + architectures                  = (known after apply)
      + arn                            = (known after apply)
      + filename                       = "basic_auth_lambda.zip"
      + function_name                  = "this-is-my-prefix-_basic_auth"
      + handler                        = "basic_auth.handler"
      + id                             = (known after apply)
      + invoke_arn                     = (known after apply)
      + last_modified                  = (known after apply)
      + memory_size                    = 128
      + package_type                   = "Zip"
      + publish                        = true
      + qualified_arn                  = (known after apply)
      + qualified_invoke_arn           = (known after apply)
      + reserved_concurrent_executions = -1
      + role                           = (known after apply)
      + runtime                        = "nodejs14.x"
      + signing_job_arn                = (known after apply)
      + signing_profile_version_arn    = (known after apply)
      + skip_destroy                   = false
      + source_code_hash               = "KQSu10uOUMW2Mcmras0XE/kfxvnLbcXfBQSMCEfMaOE="
      + source_code_size               = (known after apply)
      + tags_all                       = (known after apply)
      + timeout                        = 3
      + version                        = (known after apply)

      + ephemeral_storage {
          + size = (known after apply)
        }

      + tracing_config {
          + mode = (known after apply)
        }
    }

  # module.munki-repo.aws_s3_bucket.log_bucket will be created
  + resource "aws_s3_bucket" "log_bucket" {
      + acceleration_status         = (known after apply)
      + acl                         = (known after apply)
      + arn                         = (known after apply)
      + bucket                      = "this-is-my-prefix--munki-logs"
      + bucket_domain_name          = (known after apply)
      + bucket_prefix               = (known after apply)
      + bucket_regional_domain_name = (known after apply)
      + force_destroy               = false
      + hosted_zone_id              = (known after apply)
      + id                          = (known after apply)
      + object_lock_enabled         = (known after apply)
      + policy                      = (known after apply)
      + region                      = (known after apply)
      + request_payer               = (known after apply)
      + website_domain              = (known after apply)
      + website_endpoint            = (known after apply)

      + cors_rule {
          + allowed_headers = (known after apply)
          + allowed_methods = (known after apply)
          + allowed_origins = (known after apply)
          + expose_headers  = (known after apply)
          + max_age_seconds = (known after apply)
        }

      + grant {
          + id          = (known after apply)
          + permissions = (known after apply)
          + type        = (known after apply)
          + uri         = (known after apply)
        }

      + lifecycle_rule {
          + abort_incomplete_multipart_upload_days = (known after apply)
          + enabled                                = (known after apply)
          + id                                     = (known after apply)
          + prefix                                 = (known after apply)
          + tags                                   = (known after apply)

          + expiration {
              + date                         = (known after apply)
              + days                         = (known after apply)
              + expired_object_delete_marker = (known after apply)
            }

          + noncurrent_version_expiration {
              + days = (known after apply)
            }

          + noncurrent_version_transition {
              + days          = (known after apply)
              + storage_class = (known after apply)
            }

          + transition {
              + date          = (known after apply)
              + days          = (known after apply)
              + storage_class = (known after apply)
            }
        }

      + object_lock_configuration {
          + object_lock_enabled = (known after apply)

          + rule {
              + default_retention {
                  + days  = (known after apply)
                  + mode  = (known after apply)
                  + years = (known after apply)
                }
            }
        }

      + replication_configuration {
          + role = (known after apply)

          + rules {
              + delete_marker_replication_status = (known after apply)
              + id                               = (known after apply)
              + prefix                           = (known after apply)
              + priority                         = (known after apply)
              + status                           = (known after apply)

              + destination {
                  + account_id         = (known after apply)
                  + bucket             = (known after apply)
                  + replica_kms_key_id = (known after apply)
                  + storage_class      = (known after apply)

                  + access_control_translation {
                      + owner = (known after apply)
                    }

                  + metrics {
                      + minutes = (known after apply)
                      + status  = (known after apply)
                    }

                  + replication_time {
                      + minutes = (known after apply)
                      + status  = (known after apply)
                    }
                }

              + filter {
                  + prefix = (known after apply)
                  + tags   = (known after apply)
                }

              + source_selection_criteria {
                  + sse_kms_encrypted_objects {
                      + enabled = (known after apply)
                    }
                }
            }
        }

      + server_side_encryption_configuration {
          + rule {
              + bucket_key_enabled = (known after apply)

              + apply_server_side_encryption_by_default {
                  + kms_master_key_id = (known after apply)
                  + sse_algorithm     = (known after apply)
                }
            }
        }

      + versioning {
          + enabled    = (known after apply)
          + mfa_delete = (known after apply)
        }

      + website {
          + error_document           = (known after apply)
          + index_document           = (known after apply)
          + redirect_all_requests_to = (known after apply)
          + routing_rules            = (known after apply)
        }
    }

  # module.munki-repo.aws_s3_bucket.www will be created
  + resource "aws_s3_bucket" "www" {
      + acceleration_status         = (known after apply)
      + acl                         = (known after apply)
      + arn                         = (known after apply)
      + bucket                      = "this-is-my-prefix--munki"
      + bucket_domain_name          = (known after apply)
      + bucket_prefix               = (known after apply)
      + bucket_regional_domain_name = (known after apply)
      + force_destroy               = false
      + hosted_zone_id              = (known after apply)
      + id                          = (known after apply)
      + object_lock_enabled         = (known after apply)
      + policy                      = (known after apply)
      + region                      = (known after apply)
      + request_payer               = (known after apply)
      + website_domain              = (known after apply)
      + website_endpoint            = (known after apply)

      + cors_rule {
          + allowed_headers = (known after apply)
          + allowed_methods = (known after apply)
          + allowed_origins = (known after apply)
          + expose_headers  = (known after apply)
          + max_age_seconds = (known after apply)
        }

      + grant {
          + id          = (known after apply)
          + permissions = (known after apply)
          + type        = (known after apply)
          + uri         = (known after apply)
        }

      + lifecycle_rule {
          + abort_incomplete_multipart_upload_days = (known after apply)
          + enabled                                = (known after apply)
          + id                                     = (known after apply)
          + prefix                                 = (known after apply)
          + tags                                   = (known after apply)

          + expiration {
              + date                         = (known after apply)
              + days                         = (known after apply)
              + expired_object_delete_marker = (known after apply)
            }

          + noncurrent_version_expiration {
              + days = (known after apply)
            }

          + noncurrent_version_transition {
              + days          = (known after apply)
              + storage_class = (known after apply)
            }

          + transition {
              + date          = (known after apply)
              + days          = (known after apply)
              + storage_class = (known after apply)
            }
        }

      + logging {
          + target_bucket = (known after apply)
          + target_prefix = "logs/"
        }

      + object_lock_configuration {
          + object_lock_enabled = (known after apply)

          + rule {
              + default_retention {
                  + days  = (known after apply)
                  + mode  = (known after apply)
                  + years = (known after apply)
                }
            }
        }

      + replication_configuration {
          + role = (known after apply)

          + rules {
              + delete_marker_replication_status = (known after apply)
              + id                               = (known after apply)
              + prefix                           = (known after apply)
              + priority                         = (known after apply)
              + status                           = (known after apply)

              + destination {
                  + account_id         = (known after apply)
                  + bucket             = (known after apply)
                  + replica_kms_key_id = (known after apply)
                  + storage_class      = (known after apply)

                  + access_control_translation {
                      + owner = (known after apply)
                    }

                  + metrics {
                      + minutes = (known after apply)
                      + status  = (known after apply)
                    }

                  + replication_time {
                      + minutes = (known after apply)
                      + status  = (known after apply)
                    }
                }

              + filter {
                  + prefix = (known after apply)
                  + tags   = (known after apply)
                }

              + source_selection_criteria {
                  + sse_kms_encrypted_objects {
                      + enabled = (known after apply)
                    }
                }
            }
        }

      + server_side_encryption_configuration {
          + rule {
              + bucket_key_enabled = (known after apply)

              + apply_server_side_encryption_by_default {
                  + kms_master_key_id = (known after apply)
                  + sse_algorithm     = (known after apply)
                }
            }
        }

      + versioning {
          + enabled    = (known after apply)
          + mfa_delete = (known after apply)
        }

      + website {
          + error_document           = (known after apply)
          + index_document           = (known after apply)
          + redirect_all_requests_to = (known after apply)
          + routing_rules            = (known after apply)
        }
    }

  # module.munki-repo.aws_s3_bucket_logging.www_logging will be created
  + resource "aws_s3_bucket_logging" "www_logging" {
      + bucket        = "it-eng-cpe--munki"
      + id            = (known after apply)
      + target_bucket = "it-eng-cpe--munki-logs"
      + target_prefix = "logs/"
    }

  # module.munki-repo.aws_s3_bucket_acl.log_bucket_acl will be created
  + resource "aws_s3_bucket_acl" "log_bucket_acl" {
      + acl    = "log-delivery-write"
      + bucket = (known after apply)
      + id     = (known after apply)

      + access_control_policy {
          + grant {
              + permission = (known after apply)

              + grantee {
                  + display_name  = (known after apply)
                  + email_address = (known after apply)
                  + id            = (known after apply)
                  + type          = (known after apply)
                  + uri           = (known after apply)
                }
            }

          + owner {
              + display_name = (known after apply)
              + id           = (known after apply)
            }
        }
    }

  # module.munki-repo.aws_s3_bucket_acl.private_acl will be created
  + resource "aws_s3_bucket_acl" "private_acl" {
      + acl    = "private"
      + bucket = (known after apply)
      + id     = (known after apply)

      + access_control_policy {
          + grant {
              + permission = (known after apply)

              + grantee {
                  + display_name  = (known after apply)
                  + email_address = (known after apply)
                  + id            = (known after apply)
                  + type          = (known after apply)
                  + uri           = (known after apply)
                }
            }

          + owner {
              + display_name = (known after apply)
              + id           = (known after apply)
            }
        }
    }

  # module.munki-repo.aws_s3_bucket_lifecycle_configuration.log_bucket_lifecycle will be created
  + resource "aws_s3_bucket_lifecycle_configuration" "log_bucket_lifecycle" {
      + bucket = (known after apply)
      + id     = (known after apply)

      + rule {
          + id     = "log_bucket_lifecycle"
          + status = "Enabled"

          + transition {
              + days          = 30
              + storage_class = "STANDARD_IA"
            }
        }
    }

  # module.munki-repo.aws_s3_bucket_policy.www will be created
  + resource "aws_s3_bucket_policy" "www" {
      + bucket = (known after apply)
      + id     = (known after apply)
      + policy = (known after apply)
    }

  # module.munki-repo.aws_s3_bucket_server_side_encryption_configuration.bucket_sse_config will be created
  + resource "aws_s3_bucket_server_side_encryption_configuration" "bucket_sse_config" {
      + bucket = (known after apply)
      + id     = (known after apply)

      + rule {
          + apply_server_side_encryption_by_default {
              + sse_algorithm = "AES256"
            }
        }
    }

Plan: 12 to add, 0 to change, 0 to destroy.
```
</details>

After getting back a clean `plan`, I converged this badmammerjammer and all was hunky-dory:

```
Apply complete! Resources: 12 added, 0 changed, 0 destroyed.
```

I debated whether or not to bump the Node.js version up to v18 but I don't know enough about Node to fully understand whether or not there have been significant changes from v14 to v18 (specifically in terms of the leveraged Node.js code). AFAIK, Node.js v14 is not yet EOL so should be fine to keep it at v14 for now (given how tiny the Node.js footprint is).