### PR TITLE
Update to Node18

### DIFF
--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -11,6 +11,8 @@ resource "aws_cloudfront_distribution" "www_distribution" {
     }
   }
 
+  aliases = var.aliases
+
   enabled             = true
   default_root_object = "index.html"
   price_class         = var.price_class

--- a/lambda.tf
+++ b/lambda.tf
@@ -45,7 +45,7 @@ resource "aws_lambda_function" "basic_auth_lambda" {
   role             = aws_iam_role.iam_for_lambda.arn
   handler          = "basic_auth.handler"
   source_code_hash = data.archive_file.basic_auth_lambda_zip.output_base64sha256
-  runtime          = "nodejs14.x"
+  runtime          = "nodejs20.x"
 
   publish = true
 }

--- a/lambda.tf
+++ b/lambda.tf
@@ -45,7 +45,7 @@ resource "aws_lambda_function" "basic_auth_lambda" {
   role             = aws_iam_role.iam_for_lambda.arn
   handler          = "basic_auth.handler"
   source_code_hash = data.archive_file.basic_auth_lambda_zip.output_base64sha256
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs18.x"
 
   publish = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -6,6 +6,11 @@ variable "password" {
   description = "Password clients use."
 }
 
+variable "aliases" {
+  description = "SANS for cloudfront"
+  default = []
+}
+
 variable "munki_s3_bucket" {
   description = "The name of your s3 Bucket"
 }


### PR DESCRIPTION
node 14 is EOL in aws and 16 is on the way out shortly.

You can go to 20 but you'd need to make sure the aws provider was very new (i think 20 got support in v5.x somewhere)

I chose to PR 18 because the pinned version of aws you're using in this repo supports it and theres no eol for it yet so should be another few years before you have to dust this off again.

https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
